### PR TITLE
fix: correctly resolve user and workspace in async context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-03-24
+
+### Fixed
+
+- `aenter_workspace` and `aleave_workspace` now correctly resolve the user from async requests by awaiting `request.auser()`
+- `resolve_workspace` and `aresolve_workspace` now correctly raise `Http404` when all `workspace_requested` signal receivers return `None`
+
 ## [0.2.1] - 2026-03-19
 
 ### Added
@@ -38,7 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workspace middleware for Django WSGI/ASGI applications
 - `get_workspace` helper to retrieve the active workspace from a request
 
-[Unreleased]: https://github.com/hartungstenio/django-workspaces/compare/0.2.1...HEAD
+[Unreleased]: https://github.com/hartungstenio/django-workspaces/compare/0.2.2...HEAD
+[0.2.2]: https://github.com/hartungstenio/django-workspaces/compare/0.2.1...0.2.2
 [0.2.1]: https://github.com/hartungstenio/django-workspaces/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/hartungstenio/django-workspaces/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/hartungstenio/django-workspaces/compare/0.0.1a1...0.1.0

--- a/src/django_workspaces/__init__.py
+++ b/src/django_workspaces/__init__.py
@@ -63,6 +63,23 @@ def _resolve_user_session(
     return cast("AbstractUser | AnonymousUser", obj), session
 
 
+async def _aresolve_user_session(
+    obj: "AbstractUser | AnonymousUser | Mapping[str, Any] | HttpRequest",
+    session: SessionBase | None = None,
+) -> tuple["AbstractUser | AnonymousUser", SessionBase]:
+    if isinstance(obj, HttpRequest):
+        return await obj.auser(), obj.session
+
+    if isinstance(obj, Mapping):
+        return obj["user"], obj["session"]
+
+    if not session:
+        msg = _("You must pass both a user and a session.")
+        raise ValueError(msg)
+
+    return cast("AbstractUser | AnonymousUser", obj), session
+
+
 def _check_object_permission(user: "AbstractUser | AnonymousUser", workspace: _Workspace) -> None:
     if getattr(settings, "WORKSPACE_CHECK_OBJECT_PERMISSIONS", False):
         view_perm = f"{workspace._meta.app_label}.view_{workspace._meta.model_name}"
@@ -106,14 +123,15 @@ def resolve_workspace(user: "AbstractUser | AnonymousUser", session: SessionBase
 
     try:
         workspace_id = Workspace._meta.pk.to_python(session[SESSION_KEY])
-    except KeyError as exc:
+    except KeyError:
         responses = workspace_requested.send(Workspace, user=user)
-        if not responses:
+        try:
+            workspace = next(cast("_Workspace", value) for response in responses if (value := response[1]))
+        except StopIteration as exc:
             msg = "Could not find a workspace"
             raise Http404(msg) from exc
-
-        _, workspace = cast("tuple[Any, _Workspace]", responses[0])
-        enter_workspace(user, workspace, session)
+        else:
+            enter_workspace(user, workspace, session)
     else:
         workspace = get_object_or_404(Workspace, pk=workspace_id)
 
@@ -141,12 +159,13 @@ async def aresolve_workspace(user: "AbstractUser | AnonymousUser", session: Sess
     session_workspace = await session.aget(SESSION_KEY)
     if session_workspace is None:
         responses = await workspace_requested.asend(Workspace, user=user)
-        if not responses:
+        try:
+            workspace = next(cast("_Workspace", value) for response in responses if (value := response[1]))
+        except StopIteration as exc:
             msg = "Could not find a workspace"
-            raise Http404(msg)
-
-        _, workspace = cast("tuple[Any, _Workspace]", responses[0])
-        await aenter_workspace(user, workspace, session)
+            raise Http404(msg) from exc
+        else:
+            await aenter_workspace(user, workspace, session)
     else:
         workspace_id = Workspace._meta.pk.to_python(session_workspace)
         workspace = await aget_object_or_404(Workspace, pk=workspace_id)
@@ -316,7 +335,7 @@ async def aenter_workspace(
         :exc:`django.core.exceptions.PermissionDenied`: if permission validation is enabled
             and the user does not have view permission on the workspace.
     """
-    user, session = _resolve_user_session(obj, session)
+    user, session = await _aresolve_user_session(obj, session)
     await _acheck_object_permission(user, workspace)
     await session.aset(SESSION_KEY, workspace._meta.pk.value_to_string(workspace))
     await workspace_entered.asend(workspace.__class__, user=user, workspace=workspace)
@@ -413,7 +432,7 @@ async def aleave_workspace(
         user: the user leaving the workspace.
         session: the current session.
     """
-    user, session = _resolve_user_session(obj, session)
+    user, session = await _aresolve_user_session(obj, session)
     if await session.ahas_key(SESSION_KEY):
         workspace = await aresolve_workspace(user, session)
         await session.apop(SESSION_KEY)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,11 +16,13 @@ from django_workspaces import (
     aenter_workspace,
     aget_workspace,
     aleave_workspace,
+    aresolve_workspace,
     aswitch_workspace,
     enter_workspace,
     get_workspace,
     get_workspace_model,
     leave_workspace,
+    resolve_workspace,
     switch_workspace,
     workspace_entered,
     workspace_exited,
@@ -50,6 +52,158 @@ def test_get_workspace_model_swapped(settings: SettingsWrapper) -> None:
     assert got is apps.get_model("sites", "Site")
 
 
+def test_resolve_workspace_with_session_non_existing(settings: SettingsWrapper, client: Client) -> None:
+    """Test if :func:`resolve_workspace` raises exception when session workspace does not exist."""
+    del settings.WORKSPACE_MODEL
+
+    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
+    client.login(username="testuser", passworkd="testpw")
+    session = client.session
+    session[SESSION_KEY] = "0"
+
+    with pytest.raises(Http404):
+        resolve_workspace(user, session)
+
+
+def test_resolve_workspace_no_signal(settings: SettingsWrapper, client: Client) -> None:
+    """Test if :func:`resolve_workspace` raises exception when there are no signals to respond workspace requests."""
+    del settings.WORKSPACE_MODEL
+
+    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
+    client.login(username="testuser", passworkd="testpw")
+    session = client.session
+
+    with pytest.raises(Http404):
+        resolve_workspace(user, session)
+
+
+def test_resolve_workspace_requests_signal(settings: SettingsWrapper, client: Client) -> None:
+    """Test if :func:`resolve_workspace` uses requested workspace when there is no workspace in session."""
+    del settings.WORKSPACE_MODEL
+
+    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
+    client.login(username="testuser", passworkd="testpw")
+    expected: Workspace = Workspace.objects.create(name="test workspace")
+    session = client.session
+    mock_signal = mock.Mock(return_value=expected)
+
+    workspace_requested.connect(mock_signal)
+    try:
+        with mock.patch("django_workspaces.enter_workspace") as mock_enter:
+            got = resolve_workspace(user, session)
+
+        assert got == expected
+        mock_enter.assert_called_once_with(user, got, session)
+        mock_signal.assert_called_once_with(
+            signal=workspace_requested,
+            sender=Workspace,
+            user=user,
+        )
+    finally:
+        workspace_requested.disconnect(mock_signal)
+
+
+def test_resolve_workspace_requests_signal_none(settings: SettingsWrapper, client: Client) -> None:
+    """Test if :func:`resolve_workspace` raises exception when signal return None."""
+    del settings.WORKSPACE_MODEL
+
+    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
+    client.login(username="testuser", passworkd="testpw")
+    session = client.session
+    mock_signal = mock.Mock(return_value=None)
+
+    workspace_requested.connect(mock_signal)
+    try:
+        with pytest.raises(Http404):
+            resolve_workspace(user, session)
+    finally:
+        workspace_requested.disconnect(mock_signal)
+
+
+def test_aresolve_workspace_with_session(settings: SettingsWrapper, async_client: AsyncClient) -> None:
+    """Test if :func:`aresolve_workspace` gets the session workspace."""
+    del settings.WORKSPACE_MODEL
+
+    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
+    async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
+    expected: Workspace = Workspace.objects.create(name="test workspace")
+
+    session = async_client.session
+    session[SESSION_KEY] = str(expected.pk)
+
+    got = async_to_sync(aresolve_workspace)(user, session)
+
+    assert got == expected
+
+
+def test_aresolve_workspace_with_session_non_existing(settings: SettingsWrapper, async_client: AsyncClient) -> None:
+    """Test if :func:`aresolve_workspace` raises exception when session workspace does not exist."""
+    del settings.WORKSPACE_MODEL
+
+    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
+    async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
+    session = async_client.session
+    session[SESSION_KEY] = "0"
+
+    with pytest.raises(Http404):
+        async_to_sync(aresolve_workspace)(user, session)
+
+
+def test_aresolve_workspace_no_signal(settings: SettingsWrapper, async_client: AsyncClient) -> None:
+    """Test if :func:`aresolve_workspace` raises exception when there are no signals to respond workspace requests."""
+    del settings.WORKSPACE_MODEL
+
+    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
+    async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
+    session = async_client.session
+
+    with pytest.raises(Http404):
+        async_to_sync(aresolve_workspace)(user, session)
+
+
+def test_aresolve_workspace_requests_signal(settings: SettingsWrapper, async_client: AsyncClient) -> None:
+    """Test if :func:`aresolve_workspace` uses requested workspace when there is no workspace in session."""
+    del settings.WORKSPACE_MODEL
+
+    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
+    async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
+    expected: Workspace = Workspace.objects.create(name="test workspace")
+    session = async_client.session
+    mock_signal = mock.AsyncMock(return_value=expected)
+
+    workspace_requested.connect(mock_signal)
+    try:
+        with mock.patch("django_workspaces.aenter_workspace") as mock_aenter:
+            got = async_to_sync(aresolve_workspace)(user, session)
+
+        assert got == expected
+        mock_aenter.assert_called_once_with(user, got, session)
+        mock_signal.assert_awaited_once_with(
+            signal=workspace_requested,
+            sender=Workspace,
+            user=user,
+        )
+    finally:
+        workspace_requested.disconnect(mock_signal)
+
+
+def test_aresolve_workspace_requests_signal_none(settings: SettingsWrapper, async_client: AsyncClient) -> None:
+    """Test if :func:`aresolve_workspace` raises exception when signal return None."""
+    del settings.WORKSPACE_MODEL
+
+    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
+    async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
+    session = async_client.session
+    mock_signal = mock.AsyncMock(return_value=None)
+
+    workspace_requested.connect(mock_signal)
+    try:
+        with pytest.raises(Http404):
+            async_to_sync(aresolve_workspace)(user, session)
+    finally:
+        workspace_requested.disconnect(mock_signal)
+
+
 def test_get_workspace_with_session(settings: SettingsWrapper, rf: RequestFactory, client: Client) -> None:
     """Test if :func:`get_workspace` gets the session workspace."""
     del settings.WORKSPACE_MODEL
@@ -62,80 +216,11 @@ def test_get_workspace_with_session(settings: SettingsWrapper, rf: RequestFactor
     request.session = client.session
     request.session[SESSION_KEY] = str(expected.pk)
 
-    got = get_workspace(request)
+    with mock.patch("django_workspaces.resolve_workspace", return_value=expected) as mock_resolve:
+        got = get_workspace(request)
 
     assert got == expected
-
-
-def test_get_workspace_with_session_non_existing(settings: SettingsWrapper, rf: RequestFactory, client: Client) -> None:
-    """Test if :func:`get_workspace` raises exception when session workspace does not exist."""
-    del settings.WORKSPACE_MODEL
-
-    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
-    client.login(username="testuser", passworkd="testpw")
-    request = rf.get("/")
-    request.user = user
-    request.session = client.session
-    request.session[SESSION_KEY] = "0"
-
-    with pytest.raises(Http404):
-        get_workspace(request)
-
-
-def test_get_workspace_requests_signal(settings: SettingsWrapper, rf: RequestFactory, client: Client) -> None:
-    """Test if :func:`get_workspace` uses requested workspace when there is no workspace in session."""
-    del settings.WORKSPACE_MODEL
-
-    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
-    client.login(username="testuser", passworkd="testpw")
-    expected: Workspace = Workspace.objects.create(name="test workspace")
-    request = rf.get("/")
-    request.user = user
-    request.session = client.session
-    mock_signal = mock.Mock(return_value=expected)
-
-    workspace_requested.connect(mock_signal)
-    try:
-        with mock.patch("django_workspaces.enter_workspace") as mock_enter:
-            got = get_workspace(request)
-
-        assert got == expected
-        mock_enter.assert_called_once_with(user, got, request.session)
-        mock_signal.assert_called_once_with(
-            signal=workspace_requested,
-            sender=Workspace,
-            user=user,
-        )
-    finally:
-        workspace_requested.disconnect(mock_signal)
-
-
-def test_get_workspace_no_signal(settings: SettingsWrapper, rf: RequestFactory, client: Client) -> None:
-    """Test if :func:`get_workspace` raises exception when there are no signals to respond workspace requests."""
-    del settings.WORKSPACE_MODEL
-
-    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
-    client.login(username="testuser", passworkd="testpw")
-    request = rf.get("/")
-    request.user = user
-    request.session = client.session
-
-    with pytest.raises(Http404):
-        get_workspace(request)
-
-
-def test_get_workspace_requests_signal_none(settings: SettingsWrapper, rf: RequestFactory, client: Client) -> None:
-    """Test if :func:`get_workspace` raises exception when signal return None."""
-    del settings.WORKSPACE_MODEL
-
-    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
-    client.login(username="testuser", passworkd="testpw")
-    request = rf.get("/")
-    request.user = user
-    request.session = client.session
-
-    with pytest.raises(Http404):
-        get_workspace(request)
+    mock_resolve.assert_called_once_with(user, request.session)
 
 
 def test_get_workspace_with_header(settings: SettingsWrapper, rf: RequestFactory) -> None:
@@ -170,114 +255,18 @@ def test_aget_workspace_with_session(
 
     user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
     async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
-    expected: Workspace = Workspace.objects.create(name="test workspace")
     request = async_rf.get("/")
-
-    async def auser() -> User:
-        return user
-
-    request.auser = auser
+    request.user = user
+    request.auser = mock.AsyncMock(return_value=user)
     request.session = async_client.session
-    request.session[SESSION_KEY] = str(expected.pk)
 
-    got = async_to_sync(aget_workspace)(request)
+    expected: Workspace = Workspace.objects.create(name="test workspace")
+
+    with mock.patch("django_workspaces.aresolve_workspace", return_value=expected) as mock_resolve:
+        got = async_to_sync(aget_workspace)(request)
 
     assert got == expected
-
-
-def test_aget_workspace_with_session_non_existing(
-    settings: SettingsWrapper, async_rf: AsyncRequestFactory, async_client: AsyncClient
-) -> None:
-    """Test if :func:`aget_workspace` raises exception when session workspace does not exist."""
-    del settings.WORKSPACE_MODEL
-
-    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
-    async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
-    request = async_rf.get("/")
-
-    async def auser() -> User:
-        return user
-
-    request.auser = auser
-    request.session = async_client.session
-    request.session[SESSION_KEY] = "0"
-
-    with pytest.raises(Http404):
-        async_to_sync(aget_workspace)(request)
-
-
-def test_aget_workspace_requests_signal(
-    settings: SettingsWrapper, async_rf: AsyncRequestFactory, async_client: AsyncClient
-) -> None:
-    """Test if :func:`aget_workspace` uses requested workspace when there is no workspace in session."""
-    del settings.WORKSPACE_MODEL
-
-    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
-    async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
-    expected: Workspace = Workspace.objects.create(name="test workspace")
-    request = async_rf.get("/")
-
-    async def auser() -> User:
-        return user
-
-    request.auser = auser
-    request.session = async_client.session
-    mock_signal = mock.AsyncMock(return_value=expected)
-
-    workspace_requested.connect(mock_signal)
-    try:
-        with mock.patch("django_workspaces.aenter_workspace") as mock_aenter:
-            got = async_to_sync(aget_workspace)(request)
-
-        assert got == expected
-        mock_aenter.assert_called_once_with(user, got, request.session)
-        mock_signal.assert_awaited_once_with(
-            signal=workspace_requested,
-            sender=Workspace,
-            user=user,
-        )
-    finally:
-        workspace_requested.disconnect(mock_signal)
-
-
-def test_aget_workspace_no_signal(
-    settings: SettingsWrapper, async_rf: AsyncRequestFactory, async_client: AsyncClient
-) -> None:
-    """Test if :func:`aget_workspace` raises exception when there are no signals to respond workspace requests."""
-    del settings.WORKSPACE_MODEL
-
-    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
-    async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
-    request = async_rf.get("/")
-
-    async def auser() -> User:
-        return user
-
-    request.auser = auser
-    request.session = async_client.session
-
-    with pytest.raises(Http404):
-        async_to_sync(aget_workspace)(request)
-
-
-def test_aget_workspace_requests_signal_none(
-    settings: SettingsWrapper, async_rf: AsyncRequestFactory, async_client: AsyncClient
-) -> None:
-    """Test if :func:`aget_workspace` raises exception when signal return None."""
-    del settings.WORKSPACE_MODEL
-
-    user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
-    async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
-    request = async_rf.get("/")
-
-    async def auser() -> User:
-        return user
-
-    request.auser = auser
-    request.session = async_client.session
-
-    with pytest.raises(Http404):
-        async_to_sync(aget_workspace)(request)
+    mock_resolve.assert_awaited_once_with(user, request.session)
 
 
 def test_aget_workspace_with_header(settings: SettingsWrapper, async_rf: AsyncRequestFactory) -> None:
@@ -451,6 +440,7 @@ def test_aenter_workspace_request(
     async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
     request = async_rf.get("/")
     request.user = user
+    request.auser = mock.AsyncMock(return_value=user)
     request.session = async_client.session
 
     workspace: Workspace = Workspace.objects.create(name="test workspace")
@@ -515,6 +505,7 @@ def test_aenter_workspace_request_permission_denied(
     user = User.objects.create(username="testuser", email="test@example.com", password="testpw")  # noqa: S106
     request = async_rf.get("/")
     request.user = user
+    request.auser = mock.AsyncMock(return_value=user)
     request.session = async_client.session
     workspace: Workspace = Workspace.objects.create(name="test workspace")
 
@@ -675,6 +666,7 @@ def test_aleave_workspace_request(
     workspace: Workspace = Workspace.objects.create(name="test workspace")
     request = async_rf.get("/")
     request.user = user
+    request.auser = mock.AsyncMock(return_value=user)
     request.session = async_client.session
     request.session[SESSION_KEY] = str(workspace.pk)
     mock_signal = mock.AsyncMock()
@@ -814,6 +806,7 @@ def test_aswitch_workspace_request(
     async_to_sync(async_client.alogin)(username="testuser", passworkd="testpw")
     request = async_rf.get("/")
     request.user = user
+    request.auser = mock.AsyncMock(return_value=user)
     request.session = async_client.session
     workspace: Workspace = Workspace.objects.create(name="test workspace")
 


### PR DESCRIPTION
- Add _aresolve_user_session async helper that awaits request.auser() for HttpRequest objects, fixing aenter_workspace and aleave_workspace
- Fix resolve_workspace and aresolve_workspace to raise Http404 when all workspace_requested signal receivers return None